### PR TITLE
Fix tests and lazy-load dependencies

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -2,10 +2,10 @@
 
 from core.manager import MemoryManager
 
-# This creates a single, shared instance of the MemoryManager that will be
-# used throughout the application's lifecycle. The startup and shutdown logic
-# in main.py will manage its connections.
-memory_manager = MemoryManager()
+# Lazily create a single shared MemoryManager instance.  This avoids
+# initializing external services during module import which can cause issues
+# in test environments.
+memory_manager: MemoryManager | None = None
 
 async def get_memory_manager() -> MemoryManager:
     """
@@ -16,4 +16,7 @@ async def get_memory_manager() -> MemoryManager:
     into the endpoint's arguments. This makes testing trivial by allowing us to
     override this dependency with a mock manager.
     """
+    global memory_manager
+    if memory_manager is None:
+        memory_manager = MemoryManager()
     return memory_manager

--- a/api/routes.py
+++ b/api/routes.py
@@ -1,6 +1,7 @@
 # api/routes.py
 
 from fastapi import APIRouter, Depends, HTTPException, status, Path
+from fastapi.responses import PlainTextResponse
 from typing import Optional
 import logging
 
@@ -16,6 +17,7 @@ router = APIRouter(tags=["Memory Operations"])
 @router.get(
     "/file/{file_path:path}",
     response_model=str,
+    response_class=PlainTextResponse,
     summary="Retrieve File Content",
     description="Fetches the content of a file from the memory system, using the full L0 -> L1 -> L3 (Git) fallback logic. This is the primary endpoint for retrieving source-of-truth data."
 )

--- a/main.py
+++ b/main.py
@@ -21,7 +21,8 @@ async def lifespan(app: FastAPI):
     setup_logging(LOG_LEVEL)
     logging.info("Application startup sequence initiated.")
     try:
-        await memory_manager.startup()
+        if memory_manager is not None:
+            await memory_manager.startup()
     except MemoryLayerError as e:
         logging.critical(f"A critical memory layer failed to start: {e}. Shutting down.")
         # In a real K8s environment, this failure would cause the pod to crash-loop,
@@ -32,7 +33,8 @@ async def lifespan(app: FastAPI):
     
     # --- Shutdown ---
     logging.info("Application shutdown sequence initiated.")
-    await memory_manager.shutdown()
+    if memory_manager is not None:
+        await memory_manager.shutdown()
 
 app = FastAPI(
     title="Sentinel AI Memory Service",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,3 @@
-
-```toml
 [tool.poetry]
 name = "sentinel-memory-service"
 version = "1.0.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pydantic==2.7.1
 python-dotenv==1.0.1
 cachetools==5.3.3
 gunicorn==22.0.0
+numpy<2.0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,7 +21,7 @@ async def test_get_file_success(async_test_app_client: AsyncClient, mock_memory_
     file_content = "print('hello world')"
     mock_memory_manager.get_file_content.return_value = file_content
 
-    response = await async_test_app_client.get(f"/api/v1/memory/file/{file_path}")
+    response = await async_test_app_client.get(f"/api/v1/file/{file_path}")
 
     assert response.status_code == 200
     assert response.text == file_content
@@ -34,7 +34,7 @@ async def test_get_file_not_found(async_test_app_client: AsyncClient, mock_memor
     # Configure the mock to raise the specific exception our app handles
     mock_memory_manager.get_file_content.side_effect = NotFoundError(f"File '{file_path}' not found.")
 
-    response = await async_test_app_client.get(f"/api/v1/memory/file/{file_path}")
+    response = await async_test_app_client.get(f"/api/v1/file/{file_path}")
 
     assert response.status_code == 404
     assert response.json() == {"message": f"File '{file_path}' not found."}
@@ -45,7 +45,7 @@ async def test_get_file_memory_layer_failure(async_test_app_client: AsyncClient,
     # Configure the mock to raise a service error
     mock_memory_manager.get_file_content.side_effect = MemoryLayerError("L3-Git", "Repository is corrupted.")
 
-    response = await async_test_app_client.get(f"/api/v1/memory/file/{file_path}")
+    response = await async_test_app_client.get(f"/api/v1/file/{file_path}")
 
     assert response.status_code == 503
     assert "A required memory service is unavailable" in response.json()["message"]
@@ -62,7 +62,7 @@ async def test_semantic_search_success(async_test_app_client: AsyncClient, mock_
     mock_memory_manager.l2c.query.return_value = mock_response
     
     request_data = {"query": "test query", "top_k": 1}
-    response = await async_test_app_client.post("/api/v1/memory/search", json=request_data)
+    response = await async_test_app_client.post("/api/v1/search", json=request_data)
 
     assert response.status_code == 200
     assert response.json()["documents"][0][0] == "This is a test document."


### PR DESCRIPTION
## Summary
- fix lazy initialization of memory manager
- handle optional startup/shutdown in main
- return plain text for file endpoint
- adjust tests and test fixtures
- pin numpy for compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687583930608832ebff4378ff2ed777c