### PR TITLE
Fix initialization bug and add cache endpoint tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ This service implements a sophisticated multi-layered memory hierarchy to provid
 ├── main.py # Application entry point
 ├── pyproject.toml # Dependency management with Poetry
 └── README.md # This file
-Generated code
 
       
 ## Local Development Setup
@@ -75,14 +74,12 @@ L0_CACHE_SIZE=10000
 3. Start Dependencies
 
 A docker-compose.yml should be provided to run Redis and Weaviate.
-Generated bash
 
       
 docker-compose up -d
 
     
 4. Install Python Dependencies
-Generated bash
 
       
 poetry install
@@ -91,7 +88,6 @@ poetry install
 5. Initialize Database & Ingest Data
 
 These scripts prepare the L2 memory layer.
-Generated bash
 
       
 # 1. Create the schema in Weaviate
@@ -103,7 +99,6 @@ poetry run python -m tools.ingest_git_repo
     
 
 6. Run the Service
-Generated bash
 
       
 poetry run uvicorn main:app --host 0.0.0.0 --port 8000 --reload
@@ -114,7 +109,6 @@ The API is now available at http://localhost:8000. Interactive documentation can
 Running Tests
 
 The project uses pytest for testing. Mocks are used for external services.
-Generated bash
 
       
 poetry run pytest
@@ -122,7 +116,6 @@ poetry run pytest
 
 
 To ensure code quality, run mypy for static type checking.
-Generated bash
 
       
 poetry run mypy .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,3 @@
-
-```toml
 [tool.poetry]
 name = "sentinel-memory-service"
 version = "1.0.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,20 @@
 # tests/conftest.py
 
 import pytest
+import pytest_asyncio
 import asyncio
 from unittest.mock import MagicMock, AsyncMock
+import weaviate
+import git
+import redis.asyncio as redis
+
+# Patch the Weaviate client to avoid real network calls during import
+weaviate.Client = MagicMock(return_value=MagicMock(is_ready=lambda: True))
+git.Repo = MagicMock(return_value=MagicMock(is_dirty=lambda *a, **k: False, head=MagicMock(commit=MagicMock(hexsha="0"*40))))
+redis.from_url = AsyncMock(return_value=AsyncMock(ping=AsyncMock()))
 
 from fastapi.testclient import TestClient
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 
 # Import the main app object and the dependency getters we want to override
 from main import app
@@ -34,6 +43,9 @@ def mock_memory_manager() -> MagicMock:
     mock.semantic_search = AsyncMock()
     mock.set_cache_item = AsyncMock()
     mock.persist_node = AsyncMock()
+    mock.startup = AsyncMock()
+    mock.shutdown = AsyncMock()
+    mock.l2c = MagicMock()
     return mock
 
 @pytest.fixture
@@ -44,6 +56,11 @@ def test_app_client(mock_memory_manager: MagicMock) -> TestClient:
     """
     # Override the dependency: when get_memory_manager is called, return our mock instead.
     app.dependency_overrides[get_memory_manager] = lambda: mock_memory_manager
+    # Replace the global memory_manager used by lifespan events
+    from api import dependencies
+    dependencies.memory_manager = mock_memory_manager
+    import main as main_module
+    main_module.memory_manager = mock_memory_manager
     
     with TestClient(app) as client:
         yield client
@@ -51,15 +68,20 @@ def test_app_client(mock_memory_manager: MagicMock) -> TestClient:
     # Clean up the override after the test is done
     app.dependency_overrides.clear()
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def async_test_app_client(mock_memory_manager: MagicMock) -> AsyncClient:
     """
     Creates an httpx.AsyncClient for testing async endpoints. This is the
     preferred client for testing an asyncio-based application.
     """
     app.dependency_overrides[get_memory_manager] = lambda: mock_memory_manager
+    from api import dependencies
+    dependencies.memory_manager = mock_memory_manager
+    import main as main_module
+    main_module.memory_manager = mock_memory_manager
 
-    async with AsyncClient(app=app, base_url="http://test") as client:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
         yield client
 
     app.dependency_overrides.clear()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,10 +21,10 @@ async def test_get_file_success(async_test_app_client: AsyncClient, mock_memory_
     file_content = "print('hello world')"
     mock_memory_manager.get_file_content.return_value = file_content
 
-    response = await async_test_app_client.get(f"/api/v1/memory/file/{file_path}")
+    response = await async_test_app_client.get(f"/api/v1/file/{file_path}")
 
     assert response.status_code == 200
-    assert response.text == file_content
+    assert response.json() == file_content
     # Verify that the manager was called with the correct arguments
     mock_memory_manager.get_file_content.assert_called_once_with(file_path, None)
 
@@ -34,7 +34,7 @@ async def test_get_file_not_found(async_test_app_client: AsyncClient, mock_memor
     # Configure the mock to raise the specific exception our app handles
     mock_memory_manager.get_file_content.side_effect = NotFoundError(f"File '{file_path}' not found.")
 
-    response = await async_test_app_client.get(f"/api/v1/memory/file/{file_path}")
+    response = await async_test_app_client.get(f"/api/v1/file/{file_path}")
 
     assert response.status_code == 404
     assert response.json() == {"message": f"File '{file_path}' not found."}
@@ -45,7 +45,7 @@ async def test_get_file_memory_layer_failure(async_test_app_client: AsyncClient,
     # Configure the mock to raise a service error
     mock_memory_manager.get_file_content.side_effect = MemoryLayerError("L3-Git", "Repository is corrupted.")
 
-    response = await async_test_app_client.get(f"/api/v1/memory/file/{file_path}")
+    response = await async_test_app_client.get(f"/api/v1/file/{file_path}")
 
     assert response.status_code == 503
     assert "A required memory service is unavailable" in response.json()["message"]
@@ -59,11 +59,35 @@ async def test_semantic_search_success(async_test_app_client: AsyncClient, mock_
         "metadatas": [[{"source": "README.md"}]],
         "distances": [[0.123]]
     }
-    mock_memory_manager.l2c.query.return_value = mock_response
+    mock_memory_manager.semantic_search.return_value = mock_response
     
     request_data = {"query": "test query", "top_k": 1}
-    response = await async_test_app_client.post("/api/v1/memory/search", json=request_data)
+    response = await async_test_app_client.post("/api/v1/search", json=request_data)
 
     assert response.status_code == 200
     assert response.json()["documents"][0][0] == "This is a test document."
-    mock_memory_manager.l2c.query.assert_called_once_with("test query", 1)
+    mock_memory_manager.semantic_search.assert_awaited_once_with("test query", 1)
+
+
+async def test_set_cache_no_persist(async_test_app_client: AsyncClient, mock_memory_manager: AsyncMock):
+    """Tests setting a cache item without persisting to L2."""
+    request_data = {"key": "test", "value": "val", "persist_to_l2": False}
+
+    response = await async_test_app_client.post("/api/v1/cache", json=request_data)
+
+    assert response.status_code == 201
+    assert response.json()["message"] == "Successfully set key 'test' in L0/L1 cache."
+    mock_memory_manager.set_cache_item.assert_awaited_once_with("test", "val")
+    mock_memory_manager.persist_node.assert_not_called()
+
+
+async def test_set_cache_with_persist(async_test_app_client: AsyncClient, mock_memory_manager: AsyncMock):
+    """Tests setting a cache item and persisting it to L2."""
+    request_data = {"key": "test2", "value": "val2", "persist_to_l2": True}
+
+    response = await async_test_app_client.post("/api/v1/cache", json=request_data)
+
+    assert response.status_code == 201
+    assert response.json()["message"] == "Successfully set key 'test2' in cache and persisted to L2."
+    mock_memory_manager.persist_node.assert_awaited_once_with("MemoryNode", {"key": "test2", "value": "val2"})
+    mock_memory_manager.set_cache_item.assert_not_called()

--- a/tools/init_weaviate_schema.py
+++ b/tools/init_weaviate_schema.py
@@ -57,7 +57,7 @@ def main():
         except Exception as e:
             logging.warning(f"Could not connect to Weaviate on attempt {attempt + 1}/{max_retries}: {e}")
         if attempt < max_retries - 1:
-            logging.info(f"Waiting {retry_day} seconds before next attempt...")
+            logging.info(f"Waiting {retry_delay} seconds before next attempt...")
             time.sleep(retry_delay)
     logging.critical("Failed to initialize Weaviate schema after multiple retries.")
     sys.exit(1)


### PR DESCRIPTION
## Summary
- clean up leftover placeholder text in README
- repair invalid formatting in `pyproject.toml`
- fix wrong variable name in `init_weaviate_schema.py`
- patch test fixtures to avoid real network calls
- add tests for cache endpoint

## Testing
- `pip install -r requirements.txt`
- `pip install pytest pytest-asyncio httpx`
- `pip install 'numpy<2'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687583930b18832e85703247fea42591