### PR TITLE
Add knowledge graph module and reasoning updates

### DIFF
--- a/graphs/knowledge_graph.py
+++ b/graphs/knowledge_graph.py
@@ -1,0 +1,24 @@
+import networkx as nx
+from typing import Any, Iterable, List
+
+class KnowledgeGraph:
+    """Simple wrapper around networkx.DiGraph for asset relationships."""
+
+    def __init__(self) -> None:
+        self.graph = nx.DiGraph()
+
+    def add_asset(self, name: str, **attrs: Any) -> None:
+        """Add a node representing an asset or entity."""
+        self.graph.add_node(name, **attrs)
+
+    def add_connection(self, src: str, dst: str, **attrs: Any) -> None:
+        """Add a directed edge between two assets."""
+        self.graph.add_edge(src, dst, **attrs)
+
+    def paths(self, source: str, target: str) -> List[List[str]]:
+        """Return all simple paths between two assets."""
+        return list(nx.all_simple_paths(self.graph, source, target))
+
+    def neighbors(self, node: str) -> Iterable[str]:
+        """Return neighbors of a given asset."""
+        return self.graph.neighbors(node)

--- a/orchestrator/api/models.py
+++ b/orchestrator/api/models.py
@@ -11,5 +11,6 @@ class AnalysisRequest(BaseModel):
 class AnalysisResponse(BaseModel):
     """Response model for code analysis."""
     answer: str = Field(..., description="AI-generated answer to the query")
+    reasoning: str = Field(..., description="Step-by-step reasoning leading to the answer")
     graph_context: str = Field(..., description="Context from AST graph analysis")
     rag_context: str = Field(..., description="Context from documentation search")

--- a/orchestrator/api/routes.py
+++ b/orchestrator/api/routes.py
@@ -25,6 +25,7 @@ async def analyze_code(request: AnalysisRequest):
         
         return AnalysisResponse(
             answer=final_state.get("final_answer", "No answer generated."),
+            reasoning=final_state.get("reasoning", ""),
             graph_context=final_state.get("graph_context", ""),
             rag_context=final_state.get("rag_context", "")
         )

--- a/orchestrator/core/workflow.py
+++ b/orchestrator/core/workflow.py
@@ -17,6 +17,7 @@ class AnalysisState(TypedDict):
     graph_context: str
     rag_context: str
     combined_context: str
+    reasoning: str
     final_answer: str
     error: str | None
 
@@ -67,17 +68,24 @@ def combine_context(state: AnalysisState) -> AnalysisState:
     return state
 
 async def generate_answer(state: AnalysisState) -> AnalysisState:
-    logging.info("Workflow: Generating final answer with LLM...")
+    logging.info("Workflow: Generating final answer with LLM using CoT...")
     if state.get("error"):
         state["final_answer"] = f"Could not generate an answer due to a preceding error: {state['error']}"
         return state
 
     prompt = ChatPromptTemplate.from_messages([
-        ("system", "You are a senior software architect. Analyze the provided context from a code graph and documentation to answer the user's query with precision and clarity."),
-        ("human", "User Query: {query}\n\n--- Combined Context ---\n{context}")
+        (
+            "system",
+            "You are a senior software architect. Provide a step-by-step reasoning followed by a clear final answer.",
+        ),
+        (
+            "human",
+            "User Query: {query}\n\n--- Combined Context ---\n{context}\n\nLet's reason step by step.",
+        ),
     ])
     chain = prompt | llm
     response = await chain.ainvoke({"query": state["query"], "context": state["combined_context"]})
+    state["reasoning"] = response.content
     state["final_answer"] = response.content
     return state
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ pydantic = "^2.7.1"
 python-dotenv = "^1.0.1"
 cachetools = "^5.3.3"
 numpy = "<2.0"
+networkx = "^3.3"
+anytree = "^2.12.1"
 gunicorn = "^22.0.0" # For production deployment
 
 [tool.poetry.group.dev.dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ python-dotenv==1.0.1
 cachetools==5.3.3
 gunicorn==22.0.0
 numpy<2.0
+networkx==3.3
+anytree==2.12.1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,6 +5,24 @@ from httpx import AsyncClient
 from unittest.mock import AsyncMock
 import os
 
+# Ensure required environment variables are set for tests
+REQUIRED_ENV_VARS = [
+    "JWT_SECRET",
+    "OPENAI_API_KEY",
+    "REDIS_URL",
+    "CHROMA_HOST",
+    "CHROMA_PORT",
+    "APP_CORS_ORIGINS",
+    "LOG_LEVEL",
+    "WEAVIATE_URL",
+    "GIT_REPO_PATH",
+    "L0_CACHE_SIZE",
+    "GO_PROXY_GRPC_ADDR",
+    "CHROMA_DB_PATH",
+]
+for _var in REQUIRED_ENV_VARS:
+    os.environ.setdefault(_var, "test")
+
 from core.exceptions import NotFoundError, MemoryLayerError
 
 # Mark all tests in this file as requiring an asyncio event loop

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -1,0 +1,12 @@
+from graphs.knowledge_graph import KnowledgeGraph
+
+
+def test_path_generation():
+    graph = KnowledgeGraph()
+    graph.add_asset("A")
+    graph.add_asset("B")
+    graph.add_asset("C")
+    graph.add_connection("A", "B")
+    graph.add_connection("B", "C")
+    paths = graph.paths("A", "C")
+    assert paths == [["A", "B", "C"]]


### PR DESCRIPTION
## Summary
- integrate networkx-based KnowledgeGraph with tests
- expand orchestrator workflow to store reasoning
- update API models to return reasoning
- include new dependencies
- ensure tests work without env vars

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pytest pytest-asyncio httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68816d237f30832eb8c2e3e1fc072a8b