### PR TITLE
Add rule checks and reflection

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ A production-ready **semantic memory** micro-service that transforms unstructure
   100% pytest coverage, Locust load tests, chaos experiments. Self-auditing scripts ensure schema consistency and loop detection.
 - **Documentation & Runbooks:**\
   C4 diagrams and Pydantic schemas, Postman collections, code snippets, and operational playbooks for incident response.
+- **Graph-Based Knowledge Modeling:**\
+  Weighted, directed graphs with node and edge attributes for representing assets. See [docs/knowledge_graph.md](docs/knowledge_graph.md).
+- **Attack Tree Logic:**\
+  Hierarchical preconditions and actions with cross-links to graph assets. See [docs/attack_tree.md](docs/attack_tree.md).
+- **Reasoning Engine:**\
+  Chain- and tree-of-thought parsing with branch tracking for auditability. See [docs/reasoning_engine.md](docs/reasoning_engine.md).
+- **Vector Memory:**\
+  Store reasoning chains and attack paths in Weaviate for later recall.
+- **Symbolic Rules & Reflection:**\
+  Hard rule checks and post-run reflection utilities. See [docs/rules_and_reflection.md](docs/rules_and_reflection.md).
 
 ---
 
@@ -123,6 +133,19 @@ curl -N -X POST http://localhost:8000/api/v1/memory/query \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $JWT" \
   -d '{"query":"Explain auth flow","stream":true}'
+```
+
+### Knowledge Graph & Attack Paths
+
+```python
+from graphs.knowledge_graph import KnowledgeGraph
+
+net = KnowledgeGraph()
+net.add_asset("Server_A", os="Ubuntu", risk_score=5)
+net.add_asset("DB")
+net.add_connection("Server_A", "DB", type="sql", risk=8)
+
+print(net.paths("Server_A", "DB"))
 ```
 
 ---

--- a/core/attack_tree.py
+++ b/core/attack_tree.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""Attack tree structures for modeling preconditions and actions."""
+
+from typing import Dict, Iterable
+from anytree import Node, PreOrderIter
+import networkx as nx
+
+from graphs.knowledge_graph import KnowledgeGraph
+
+
+class AttackTree:
+    """Hierarchical attack or decision logic with cross links."""
+
+    def __init__(self, root: str) -> None:
+        self.root = Node(root)
+        self._nodes: Dict[str, Node] = {root: self.root}
+        self._graph = nx.DiGraph()
+        self._graph.add_node(root)
+        self._asset_map: Dict[str, str] = {}
+
+    def add_child(self, parent: str, child: str) -> None:
+        """Add a child node under ``parent``."""
+        if parent not in self._nodes:
+            raise ValueError(f"Parent '{parent}' not found")
+        node = Node(child, parent=self._nodes[parent])
+        self._nodes[child] = node
+        self._graph.add_node(child)
+        self._graph.add_edge(parent, child)
+
+    def traverse(self) -> Iterable[str]:
+        """Return a preorder listing of node names."""
+        return [n.name for n in PreOrderIter(self.root)]
+
+    def link_asset(self, node: str, asset: str) -> None:
+        """Associate a tree node with an asset in the knowledge graph."""
+        if node not in self._nodes:
+            raise ValueError(f"Node '{node}' not found")
+        self._asset_map[node] = asset
+
+    def link_asset_from_graph(self, graph: "KnowledgeGraph", node: str, asset: str) -> None:
+        """Link a tree node to an existing asset in ``graph``."""
+        if asset not in graph.graph:
+            raise ValueError(f"Asset '{asset}' not present in graph")
+        self.link_asset(node, asset)
+
+    def get_asset(self, node: str) -> str | None:
+        """Retrieve the associated asset for a node if one exists."""
+        return self._asset_map.get(node)
+
+    def add_alternate_path(self, src: str, dst: str) -> None:
+        """Add a cross-link representing an alternate attack step."""
+        if src not in self._nodes or dst not in self._nodes:
+            raise ValueError("Both nodes must exist in the tree")
+        self._graph.add_edge(src, dst)
+
+    def has_cycle(self) -> bool:
+        """Return ``True`` if cross-links introduce a cycle."""
+        try:
+            nx.find_cycle(self._graph, orientation="original")
+            return True
+        except nx.exception.NetworkXNoCycle:
+            return False
+
+    def is_dead_end(self, node: str) -> bool:
+        """Return ``True`` if ``node`` has no children."""
+        if node not in self._nodes:
+            raise ValueError(f"Node '{node}' not found")
+        return len(self._nodes[node].children) == 0

--- a/core/reasoning.py
+++ b/core/reasoning.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+"""Reasoning utilities for Chain/Tree/Graph-of-Thought."""
+
+from typing import List
+import re
+from anytree import Node, PreOrderIter
+import networkx as nx
+
+
+def parse_reasoning_steps(text: str) -> List[str]:
+    """Extract reasoning steps from an LLM answer."""
+    steps: List[str] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        m = re.match(r"^\d+[\.)]\s*(.*)", line)
+        if m:
+            steps.append(m.group(1))
+            continue
+        if line.startswith("- "):
+            steps.append(line[2:])
+            continue
+    if not steps and text.strip():
+        steps.append(text.strip())
+    return steps
+
+
+class ReasoningTree:
+    """Simple container for branching reasoning paths."""
+
+    def __init__(self, root_text: str) -> None:
+        self.root = Node("root", text=root_text)
+        self._nodes = {"root": self.root}
+        self._graph = nx.DiGraph()
+        self._graph.add_node("root", text=root_text)
+        self._counter = 0
+
+    def add_branches(self, parent: str, branches: List[str]) -> List[str]:
+        if parent not in self._nodes:
+            raise ValueError(f"Parent '{parent}' not found")
+        ids: List[str] = []
+        for text in branches:
+            self._counter += 1
+            node_id = f"n{self._counter}"
+            node = Node(node_id, parent=self._nodes[parent], text=text)
+            self._nodes[node_id] = node
+            self._graph.add_node(node_id, text=text)
+            self._graph.add_edge(parent, node_id)
+            ids.append(node_id)
+        return ids
+
+    def traverse(self) -> List[str]:
+        """Return preorder list of node texts."""
+        return [n.text for n in PreOrderIter(self.root)]

--- a/core/reflection.py
+++ b/core/reflection.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+"""Self-reflection utilities."""
+
+from datetime import datetime
+
+
+def reflect(outcome: str, log_file: str = "reflection.log") -> str:
+    """Log the outcome and return a simple lesson learned."""
+
+    timestamp = datetime.utcnow().isoformat()
+    with open(log_file, "a", encoding="utf-8") as f:
+        f.write(f"{timestamp} - {outcome}\n")
+
+    lower = outcome.lower()
+    if "fail" in lower or "error" in lower:
+        return "Identify root cause and adjust strategy."
+    return "Approach succeeded; reinforce successful steps."

--- a/core/rules.py
+++ b/core/rules.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Hard constraints for attack simulations or workflows."""
+
+from graphs.knowledge_graph import KnowledgeGraph
+
+
+class RuleViolation(Exception):
+    """Raised when a rule check fails."""
+
+
+def check_db_access(graph: KnowledgeGraph) -> None:
+    """Ensure the firewall has been bypassed before DB access.
+
+    Looks for a node named ``Firewall``. If present and its ``bypassed``
+    attribute is not ``True``, access to the ``DB`` node is forbidden and a
+    :class:`RuleViolation` is raised.
+    """
+
+    if "Firewall" in graph.graph and "DB" in graph.graph:
+        fw = graph.graph.nodes["Firewall"]
+        if not fw.get("bypassed", False):
+            raise RuleViolation("No access to DB unless firewall bypassed.")
+
+
+def run_pre_execution_checks(graph: KnowledgeGraph) -> None:
+    """Run all rule checks against ``graph``."""
+
+    check_db_access(graph)

--- a/docs/attack_tree.md
+++ b/docs/attack_tree.md
@@ -1,0 +1,44 @@
+# Attack Trees
+
+`AttackTree` models prerequisite actions as a hierarchy that can reference assets in the knowledge graph.
+
+## Basic Usage
+
+```python
+from core.attack_tree import AttackTree
+
+# create the tree
+tree = AttackTree("Gain_DB_Access")
+tree.add_child("Gain_DB_Access", "Exploit_Firewall")
+tree.add_child("Gain_DB_Access", "Phish_Admin")
+```
+
+Nodes may link to assets or connections stored in the knowledge graph:
+
+```python
+from graphs.knowledge_graph import KnowledgeGraph
+
+net = KnowledgeGraph()
+net.add_asset("Server_B")
+
+tree.add_child("Exploit_Firewall", "Exploit_Server_B")
+tree.link_asset("Exploit_Server_B", "Server_B")
+```
+
+Alternate attack paths can be represented with cross-links and cycles are detected automatically:
+
+```python
+# create a shortcut from phishing to exploiting the firewall
+tree.add_alternate_path("Phish_Admin", "Exploit_Firewall")
+if tree.has_cycle():
+    print("cycle detected")
+```
+
+## Advanced
+
+Check for dead ends when traversing a tree:
+
+```python
+leaf = "Exploit_Server_B"
+print(tree.is_dead_end(leaf))  # True when no further actions are defined
+```

--- a/docs/knowledge_graph.md
+++ b/docs/knowledge_graph.md
@@ -1,0 +1,37 @@
+# Knowledge Graph
+
+Sentinel AI includes a lightweight wrapper around `networkx` for representing assets and their relationships.
+Nodes and edges accept arbitrary attributes so you can capture properties like operating system, credentials,
+vulnerabilities or connection risk.
+
+## Basic Usage
+
+```python
+from graphs.knowledge_graph import KnowledgeGraph
+
+net = KnowledgeGraph()
+net.add_asset("Server_A", os="Ubuntu", vulnerabilities=["CVE-2023-1234"])
+net.add_asset("DB", sensitive=True)
+net.add_connection("Server_A", "DB", type="sql", risk=8, weight=0.5)
+
+print(net.get_asset_attrs("Server_A"))
+print(net.get_connection_attrs("Server_A", "DB"))
+path = net.shortest_path("Server_A", "DB")
+print(path)
+```
+
+`shortest_path` uses edge weights when present to calculate the lowest-cost route.
+Attack tree nodes can reference assets in this graph for hybrid reasoning.
+
+## Advanced
+
+List possible attack paths and detect when none are available:
+
+```python
+paths = net.paths("Server_A", "DB")
+if not paths:
+    print("no path available")
+else:
+    for p in paths:
+        print(" -> ".join(p))
+```

--- a/docs/reasoning_engine.md
+++ b/docs/reasoning_engine.md
@@ -1,0 +1,14 @@
+# Reasoning Engine
+
+The reasoning engine parses step-by-step answers from the LLM and stores them as structured data. Each step becomes a node in a small tree so alternate branches can be explored later.
+
+```python
+from core.reasoning import parse_reasoning_steps, ReasoningTree
+
+text = "1. Scan open ports\n2. Exploit service\nFinished."
+steps = parse_reasoning_steps(text)
+
+rtree = ReasoningTree("analysis")
+rtree.add_branches("root", steps)
+print(rtree.traverse())
+```

--- a/docs/rules_and_reflection.md
+++ b/docs/rules_and_reflection.md
@@ -1,0 +1,32 @@
+# Symbolic Rules & Reflection
+
+These modules provide a basic framework for enforcing hard constraints and logging lessons learned after each run.
+
+## Rule Checks
+
+```python
+from graphs.knowledge_graph import KnowledgeGraph
+from core.rules import run_pre_execution_checks, RuleViolation
+
+net = KnowledgeGraph()
+net.add_asset("Firewall")
+net.add_asset("DB")
+
+# raises RuleViolation until firewall is marked bypassed
+try:
+    run_pre_execution_checks(net)
+except RuleViolation:
+    net.graph.nodes["Firewall"]["bypassed"] = True
+    run_pre_execution_checks(net)
+```
+
+## Reflection
+
+```python
+from core.reflection import reflect
+
+lesson = reflect("simulation success")
+print(lesson)
+```
+
+Call `reflect()` after each attack simulation or agent action to capture the outcome and generate a brief lesson learned.

--- a/graphs/knowledge_graph.py
+++ b/graphs/knowledge_graph.py
@@ -1,23 +1,63 @@
 import networkx as nx
-from typing import Any, Iterable, List
+from typing import Any, Iterable, List, Dict
 
 class KnowledgeGraph:
-    """Simple wrapper around networkx.DiGraph for asset relationships."""
+    """Wrapper around networkx graphs for modeling asset relationships."""
 
-    def __init__(self) -> None:
-        self.graph = nx.DiGraph()
+    def __init__(self, directed: bool = True) -> None:
+        """Initialize the graph.
+
+        Parameters
+        ----------
+        directed:
+            If ``True`` (default) a :class:`~networkx.DiGraph` is used.
+            Otherwise a standard undirected graph is created.
+        """
+        self.graph = nx.DiGraph() if directed else nx.Graph()
 
     def add_asset(self, name: str, **attrs: Any) -> None:
-        """Add a node representing an asset or entity."""
+        """Add a node representing an asset or entity with attributes."""
         self.graph.add_node(name, **attrs)
 
-    def add_connection(self, src: str, dst: str, **attrs: Any) -> None:
-        """Add a directed edge between two assets."""
+    def get_asset_attrs(self, name: str) -> Dict[str, Any]:
+        """Return the attribute dictionary for a given asset."""
+        return dict(self.graph.nodes[name])
+
+    def add_connection(self, src: str, dst: str, weight: float = 1.0, **attrs: Any) -> None:
+        """Add an edge between two assets.
+
+        Parameters
+        ----------
+        src, dst:
+            Source and destination asset names.
+        weight:
+            Numeric edge weight used for path scoring (default ``1.0``).
+        attrs:
+            Additional edge attributes such as ``type`` or ``risk``.
+        """
+        attrs.setdefault("weight", weight)
         self.graph.add_edge(src, dst, **attrs)
+
+    def add_directed_connection(self, src: str, dst: str, weight: float = 1.0, **attrs: Any) -> None:
+        """Explicitly add a directed edge even when using an undirected graph."""
+        attrs.setdefault("weight", weight)
+        if isinstance(self.graph, nx.DiGraph):
+            self.graph.add_edge(src, dst, **attrs)
+        else:
+            self.graph.add_edge(src, dst, **attrs)
+
+    def get_connection_attrs(self, src: str, dst: str) -> Dict[str, Any]:
+        """Return attribute dictionary for a connection."""
+        data = self.graph.get_edge_data(src, dst)
+        return dict(data) if data else {}
 
     def paths(self, source: str, target: str) -> List[List[str]]:
         """Return all simple paths between two assets."""
         return list(nx.all_simple_paths(self.graph, source, target))
+
+    def shortest_path(self, source: str, target: str, weight: str = "weight") -> List[str]:
+        """Return the weighted shortest path between two assets."""
+        return nx.shortest_path(self.graph, source, target, weight=weight)
 
     def neighbors(self, node: str) -> Iterable[str]:
         """Return neighbors of a given asset."""

--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -1,0 +1,1 @@
+"""Memory utilities."""

--- a/memory/vector_store.py
+++ b/memory/vector_store.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Simple vector store client backed by Weaviate."""
+
+from typing import Any, List, Optional
+import hashlib
+
+import numpy as np
+import weaviate
+
+
+class VectorStore:
+    """Store and retrieve reasoning chains or attack paths as vectors."""
+
+    def __init__(
+        self,
+        url: str,
+        class_name: str = "ReasoningMemory",
+        client: Optional[Any] = None,
+    ) -> None:
+        self.client = client or weaviate.Client(url)
+        if not self.client.is_ready():
+            raise ConnectionError("Weaviate server is not ready")
+        self.class_name = class_name
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        if hasattr(self.client, "schema") and hasattr(self.client.schema, "contains"):
+            if not self.client.schema.contains({"class": self.class_name}):
+                schema = {
+                    "classes": [
+                        {
+                            "class": self.class_name,
+                            "vectorizer": "none",
+                            "properties": [{"name": "text", "dataType": ["text"]}],
+                        }
+                    ]
+                }
+                self.client.schema.create(schema)
+
+    @staticmethod
+    def _embed(text: str) -> List[float]:
+        digest = hashlib.sha256(text.encode()).digest()
+        # Normalize bytes to floats for a deterministic embedding
+        return [b / 255.0 for b in digest[:32]]
+
+    def add_entry(self, text: str) -> str:
+        vector = self._embed(text)
+        return self.client.data_object.create(
+            data_object={"text": text}, class_name=self.class_name, vector=vector
+        )
+
+    def query_similar(self, text: str, top_k: int = 3) -> List[str]:
+        vector = self._embed(text)
+        result = (
+            self.client.query.get(self.class_name, ["text"])
+            .with_near_vector({"vector": vector})
+            .with_limit(top_k)
+            .do()
+        )
+        docs = result.get("data", {}).get("Get", {}).get(self.class_name, [])
+        return [d["text"] for d in docs]

--- a/orchestrator/api/models.py
+++ b/orchestrator/api/models.py
@@ -1,6 +1,6 @@
 # orchestrator/api/models.py
 from pydantic import BaseModel, Field
-from typing import Optional
+from typing import Optional, List
 
 class AnalysisRequest(BaseModel):
     """Request model for code analysis."""
@@ -12,5 +12,6 @@ class AnalysisResponse(BaseModel):
     """Response model for code analysis."""
     answer: str = Field(..., description="AI-generated answer to the query")
     reasoning: str = Field(..., description="Step-by-step reasoning leading to the answer")
+    reasoning_steps: list[str] = Field(..., description="Parsed reasoning steps")
     graph_context: str = Field(..., description="Context from AST graph analysis")
     rag_context: str = Field(..., description="Context from documentation search")

--- a/orchestrator/api/routes.py
+++ b/orchestrator/api/routes.py
@@ -26,6 +26,7 @@ async def analyze_code(request: AnalysisRequest):
         return AnalysisResponse(
             answer=final_state.get("final_answer", "No answer generated."),
             reasoning=final_state.get("reasoning", ""),
+            reasoning_steps=final_state.get("reasoning_steps", []),
             graph_context=final_state.get("graph_context", ""),
             rag_context=final_state.get("rag_context", "")
         )

--- a/tests/test_attack_tree.py
+++ b/tests/test_attack_tree.py
@@ -1,0 +1,33 @@
+from core.attack_tree import AttackTree
+from graphs.knowledge_graph import KnowledgeGraph
+
+
+def test_tree_traversal():
+    tree = AttackTree("Gain_DB_Access")
+    tree.add_child("Gain_DB_Access", "Exploit_Firewall")
+    tree.add_child("Gain_DB_Access", "Phish_Admin")
+    assert tree.traverse()[:3] == ["Gain_DB_Access", "Exploit_Firewall", "Phish_Admin"]
+
+
+def test_mapping_and_cycle_detection():
+    graph = KnowledgeGraph()
+    graph.add_asset("Server_B")
+
+    tree = AttackTree("Root")
+    tree.add_child("Root", "Exploit_Server_B")
+    tree.link_asset("Exploit_Server_B", "Server_B")
+
+    assert tree.get_asset("Exploit_Server_B") == "Server_B"
+    assert not tree.has_cycle()
+
+    tree.add_alternate_path("Exploit_Server_B", "Root")
+    assert tree.has_cycle()
+
+
+def test_dead_end_detection():
+    tree = AttackTree("Root")
+    tree.add_child("Root", "Step1")
+    tree.add_child("Step1", "Leaf")
+
+    assert tree.is_dead_end("Leaf")
+    assert not tree.is_dead_end("Step1")

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -10,3 +10,60 @@ def test_path_generation():
     graph.add_connection("B", "C")
     paths = graph.paths("A", "C")
     assert paths == [["A", "B", "C"]]
+
+
+def test_attributes_and_weights():
+    graph = KnowledgeGraph()
+    graph.add_asset("Server_A", os="Ubuntu", vulnerabilities=["CVE-2023-1234"])
+    graph.add_asset("DB")
+    graph.add_connection("Server_A", "DB", type="sql", risk=8, weight=2)
+
+    assert graph.get_asset_attrs("Server_A")["os"] == "Ubuntu"
+    edge_attrs = graph.get_connection_attrs("Server_A", "DB")
+    assert edge_attrs["risk"] == 8
+    assert edge_attrs["weight"] == 2
+
+
+def test_weighted_shortest_path():
+    graph = KnowledgeGraph()
+    graph.add_asset("A")
+    graph.add_asset("B")
+    graph.add_asset("C")
+    graph.add_connection("A", "B", weight=5)
+    graph.add_connection("A", "C", weight=1)
+    graph.add_connection("C", "B", weight=1)
+
+    assert graph.shortest_path("A", "B") == ["A", "C", "B"]
+
+
+def test_no_path_available():
+    graph = KnowledgeGraph()
+    graph.add_asset("A")
+    graph.add_asset("B")
+    graph.add_asset("C")
+    graph.add_connection("A", "B")
+
+    assert graph.paths("A", "C") == []
+
+    import pytest
+    import networkx as nx
+    with pytest.raises(nx.NetworkXNoPath):
+        graph.shortest_path("A", "C")
+
+
+def test_multiple_valid_paths():
+    graph = KnowledgeGraph()
+    graph.add_asset("A")
+    graph.add_asset("B")
+    graph.add_asset("C")
+    graph.add_asset("D")
+    graph.add_connection("A", "B", weight=1)
+    graph.add_connection("A", "C", weight=2)
+    graph.add_connection("C", "B", weight=1)
+    graph.add_connection("A", "D", weight=2)
+    graph.add_connection("D", "B", weight=1)
+
+    paths = graph.paths("A", "B")
+    expected = [["A", "B"], ["A", "C", "B"], ["A", "D", "B"]]
+    assert sorted(paths) == sorted(expected)
+    assert graph.shortest_path("A", "B") == ["A", "B"]

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -1,0 +1,13 @@
+from core.reasoning import parse_reasoning_steps, ReasoningTree
+
+
+def test_parse_reasoning_steps():
+    text = "1. Step one\n2. Step two\nFinal answer."
+    steps = parse_reasoning_steps(text)
+    assert steps == ["Step one", "Step two"]
+
+
+def test_reasoning_tree_traversal():
+    tree = ReasoningTree("start")
+    tree.add_branches("root", ["A", "B"])
+    assert tree.traverse() == ["start", "A", "B"]

--- a/tests/test_rules_reflection.py
+++ b/tests/test_rules_reflection.py
@@ -1,0 +1,24 @@
+from core.rules import run_pre_execution_checks, RuleViolation
+from core.reflection import reflect
+from graphs.knowledge_graph import KnowledgeGraph
+
+
+def test_rule_violation_and_pass():
+    graph = KnowledgeGraph()
+    graph.add_asset("Firewall")
+    graph.add_asset("DB")
+
+    # Should raise until firewall bypassed
+    try:
+        run_pre_execution_checks(graph)
+    except RuleViolation:
+        graph.graph.nodes["Firewall"]["bypassed"] = True
+        run_pre_execution_checks(graph)
+
+
+def test_reflection(tmp_path):
+    log_file = tmp_path / "log.txt"
+    lesson = reflect("operation success", log_file=str(log_file))
+    assert "success" in lesson.lower()
+    content = log_file.read_text()
+    assert "operation success" in content

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,0 +1,61 @@
+from memory.vector_store import VectorStore
+import numpy as np
+from types import SimpleNamespace
+
+
+class FakeQuery:
+    def __init__(self, store, class_name):
+        self.store = store
+        self.class_name = class_name
+        self.vector = []
+        self.limit = 0
+
+    def get(self, class_name, props):
+        self.class_name = class_name
+        return self
+
+    def with_near_vector(self, near):
+        self.vector = near["vector"]
+        return self
+
+    def with_limit(self, k):
+        self.limit = k
+        return self
+
+    def do(self):
+        sims = []
+        for item in self.store:
+            v = np.array(item["vector"])
+            q = np.array(self.vector)
+            s = float(v.dot(q) / (np.linalg.norm(v) * np.linalg.norm(q)))
+            sims.append((s, item["text"]))
+        sims.sort(reverse=True)
+        data = [{"text": t} for _, t in sims[: self.limit]]
+        return {"data": {"Get": {self.class_name: data}}}
+
+
+class FakeClient:
+    def __init__(self):
+        self.store = []
+        self.schema = SimpleNamespace(contains=lambda x: True, create=lambda x: None)
+        self.data_object = SimpleNamespace(create=self._create)
+        self.query = SimpleNamespace(get=self._get)
+
+    def _create(self, data_object, class_name, vector):
+        self.store.append({"text": data_object["text"], "vector": vector})
+        return str(len(self.store))
+
+    def _get(self, class_name, props):
+        return FakeQuery(self.store, class_name)
+
+    def is_ready(self):
+        return True
+
+
+def test_add_and_query(monkeypatch):
+    fake_client = FakeClient()
+    store = VectorStore(url="http://test", client=fake_client)
+    store.add_entry("compromise server")
+    store.add_entry("backup data")
+    results = store.query_similar("compromise server", top_k=1)
+    assert results == ["compromise server"]


### PR DESCRIPTION
## Summary
- implement symbolic rules for firewall bypass and DB access
- add simple self-reflection utility with logging
- document the new modules and usage
- extend README feature list
- test rule enforcement and reflection logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68816d237f30832eb8c2e3e1fc072a8b