### PR TITLE
Fix optional torch import and update API examples

### DIFF
--- a/advanced/temporal_module.py
+++ b/advanced/temporal_module.py
@@ -1,4 +1,5 @@
 """Temporal Sequence Modeling utilities."""
+
 from __future__ import annotations
 
 import time
@@ -25,18 +26,28 @@ class TemporalSequenceLogger:
         return self._logs.get(user_id, [])
 
 
-class LSTMPredictor(nn.Module):
-    """Simple LSTM model for sequence prediction demo."""
+if nn is not None:
 
-    def __init__(self, vocab_size: int, hidden_size: int = 16) -> None:
-        if nn is None:
+    class LSTMPredictor(nn.Module):
+        """Simple LSTM model for sequence prediction demo."""
+
+        def __init__(self, vocab_size: int, hidden_size: int = 16) -> None:
+            super().__init__()
+            self.embed = nn.Embedding(vocab_size, hidden_size)
+            self.lstm = nn.LSTM(hidden_size, hidden_size, batch_first=True)
+            self.fc = nn.Linear(hidden_size, vocab_size)
+
+        def forward(
+            self, x: torch.Tensor
+        ) -> torch.Tensor:  # pragma: no cover - optional dependency
+            emb = self.embed(x)
+            out, _ = self.lstm(emb)
+            return self.fc(out[:, -1, :])
+
+else:  # pragma: no cover - optional dependency
+
+    class LSTMPredictor:
+        """Stub when PyTorch is unavailable."""
+
+        def __init__(self, *_: object, **__: object) -> None:
             raise RuntimeError("PyTorch is required for LSTMPredictor")
-        super().__init__()
-        self.embed = nn.Embedding(vocab_size, hidden_size)
-        self.lstm = nn.LSTM(hidden_size, hidden_size, batch_first=True)
-        self.fc = nn.Linear(hidden_size, vocab_size)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        emb = self.embed(x)
-        out, _ = self.lstm(emb)
-        return self.fc(out[:, -1, :])

--- a/api/models.py
+++ b/api/models.py
@@ -5,64 +5,78 @@ from typing import List, Dict, Any, Optional
 
 # --- Request Models ---
 
+
 class SetMemoryRequest(BaseModel):
     """
     Defines the request body for setting or updating a memory item.
     """
+
     key: str = Field(
-        ..., 
+        ...,
         description="The unique key for the memory item. For files, this should be the file path.",
-        example="src/utils/helpers.py"
+        examples={
+            "default": {"summary": "Sample key", "value": "src/utils/helpers.py"}
+        },
     )
     value: Any = Field(
-        ..., 
-        description="The value to store. Can be any JSON-serializable type."
+        ..., description="The value to store. Can be any JSON-serializable type."
     )
     persist_to_l2: bool = Field(
-        False, 
-        description="If true, the item will be persisted to the L2 Weaviate layer for long-term storage."
+        False,
+        description="If true, the item will be persisted to the L2 Weaviate layer for long-term storage.",
     )
+
 
 class SemanticSearchRequest(BaseModel):
     """
     Defines the request body for performing a semantic search.
     """
+
     query: str = Field(
-        ..., 
+        ...,
         description="The natural language query for semantic search against the L2 ChromaDB layer.",
-        example="What is the purpose of the MemoryManager?"
+        examples={
+            "default": {
+                "summary": "Sample question",
+                "value": "What is the purpose of the MemoryManager?",
+            }
+        },
     )
     top_k: int = Field(
-        5, 
-        gt=0, 
-        le=50, 
-        description="The number of top results to return."
+        5, gt=0, le=50, description="The number of top results to return."
     )
 
+
 # --- Response Models ---
+
 
 class SetMemoryResponse(BaseModel):
     """
     Defines the response body after successfully setting a memory item.
     """
+
     key: str
     status: str
     message: str
+
 
 class SemanticSearchResponse(BaseModel):
     """
     Defines the structured response for a semantic search query.
     Mirrors the structure returned by the ChromaDB client.
     """
+
     ids: List[List[str]]
     documents: List[List[str]]
     metadatas: List[List[Dict[str, Any]]]
     distances: List[List[float]]
 
+
 class ErrorResponse(BaseModel):
     """
     A generic error response model for consistent error reporting.
     """
+
     message: str
 
 
@@ -80,4 +94,3 @@ class AgentRunResponse(BaseModel):
 
 class FuseResponse(BaseModel):
     vector: List[float]
-    

--- a/api/routes.py
+++ b/api/routes.py
@@ -14,19 +14,26 @@ from core.utils import validate_file_path, validate_commit_hash
 # included in the main FastAPI app with a prefix.
 router = APIRouter(prefix="/memory", tags=["Memory Operations"])
 
+
 @router.get(
     "/file/{file_path:path}",
     response_model=str,
     response_class=PlainTextResponse,
     summary="Retrieve File Content",
-    description="Fetches the content of a file from the memory system, using the full L0 -> L1 -> L3 (Git) fallback logic. This is the primary endpoint for retrieving source-of-truth data."
+    description="Fetches the content of a file from the memory system, using the full L0 -> L1 -> L3 (Git) fallback logic. This is the primary endpoint for retrieving source-of-truth data.",
 )
 async def get_file_from_memory(
-    file_path: str = Path(..., description="The full path to the file within the configured Git repository.", example="src/main.py"),
+    file_path: str = Path(
+        ...,
+        description="The full path to the file within the configured Git repository.",
+        examples={"default": {"summary": "Sample file", "value": "src/main.py"}},
+    ),
     commit_hash: Optional[str] = None,
-    manager: MemoryManager = Depends(get_memory_manager)
+    manager: MemoryManager = Depends(get_memory_manager),
 ):
-    logging.info(f"API request for file: {file_path} at commit: {commit_hash or 'latest'}")
+    logging.info(
+        f"API request for file: {file_path} at commit: {commit_hash or 'latest'}"
+    )
 
     try:
         file_path = validate_file_path(file_path)
@@ -40,36 +47,38 @@ async def get_file_from_memory(
     # Exceptions raised by the manager will be caught by the handlers in main.py.
     return await manager.get_file_content(file_path, commit_hash)
 
+
 @router.post(
     "/search",
     response_model=SemanticSearchResponse,
     summary="Perform Semantic Search",
-    description="Performs a semantic search against the L2 (ChromaDB) memory layer to find relevant documents (e.g., READMEs, docstrings) based on a natural language query."
+    description="Performs a semantic search against the L2 (ChromaDB) memory layer to find relevant documents (e.g., READMEs, docstrings) based on a natural language query.",
 )
 async def search_semantic_memory(
-    request: SemanticSearchRequest,
-    manager: MemoryManager = Depends(get_memory_manager)
+    request: SemanticSearchRequest, manager: MemoryManager = Depends(get_memory_manager)
 ):
     logging.info(f"API performing semantic search for query: '{request.query}'")
     results = await manager.semantic_search(request.query, request.top_k)
     # The response from ChromaDB already matches the desired structure.
     return results
 
+
 @router.post(
     "/cache",
     response_model=SetMemoryResponse,
     status_code=status.HTTP_201_CREATED,
     summary="Set a Cache Item",
-    description="Sets a value in the cache (L0/L1) and optionally persists it to the L2 (Weaviate) layer for long-term structured storage. Useful for storing computed results from AI analysis."
+    description="Sets a value in the cache (L0/L1) and optionally persists it to the L2 (Weaviate) layer for long-term structured storage. Useful for storing computed results from AI analysis.",
 )
 async def set_memory_item(
-    request: SetMemoryRequest,
-    manager: MemoryManager = Depends(get_memory_manager)
+    request: SetMemoryRequest, manager: MemoryManager = Depends(get_memory_manager)
 ):
     logging.info(f"API setting memory for key: {request.key}")
     if request.persist_to_l2:
         # This demonstrates calling the persistence logic
-        await manager.persist_node("MemoryNode", {"key": request.key, "value": request.value})
+        await manager.persist_node(
+            "MemoryNode", {"key": request.key, "value": request.value}
+        )
         message = f"Successfully set key '{request.key}' in cache and persisted to L2."
     else:
         # This demonstrates calling the cache-only logic


### PR DESCRIPTION
## Summary
- handle missing `torch` more gracefully in `advanced.temporal_module`
- update request models to use `examples` instead of deprecated `example`
- use `examples` in API path parameter
- format touched files with `black`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6882083c59e0832e8262029bbc0af13d