### PR TITLE
Refactor main and manager, update tests

### DIFF
--- a/core/manager.py
+++ b/core/manager.py
@@ -28,11 +28,7 @@ class MemoryManager:
         self.l2w = L2Weaviate(WEAVIATE_URL)
         self.l2c = L2Chroma(CHROMA_PATH)
         self.l3 = L3Git(GIT_REPO_PATH)
-
-        # The _locks dictionary holds an asyncio.Lock for each key currently being fetched.
-        # This is the core of the cache stampede protection mechanism.
         self._locks: Dict[str, asyncio.Lock] = {}
-        # The _locks_lock protects the _locks dictionary itself from concurrent modification.
         self._locks_lock = asyncio.Lock()
 
     async def startup(self):
@@ -41,8 +37,6 @@ class MemoryManager:
         This method is called once during the application's startup lifecycle.
         """
         await self.l1.connect()
-        # L2/L3 clients are initialized in their constructors, but any async
-        # connection logic would go here.
         logging.info("MemoryManager started up and all memory layers initialized.")
 
     async def shutdown(self):
@@ -56,12 +50,6 @@ class MemoryManager:
     def _generate_cache_key(self, prefix: str, identifier: str, version: Optional[str] = None) -> str:
         """
         Creates a consistent, hashed key for caching to avoid issues with key length or special characters.
-        Args:
-            prefix: A category for the key (e.g., "file", "ast").
-            identifier: The main identifier (e.g., file path).
-            version: An optional version tag (e.g., commit hash).
-        Returns:
-            A SHA256 hashed key prefixed for namespacing.
         """
         key_string = f"{prefix}:{identifier}:{version or 'latest'}"
         return f"cache:{hashlib.sha256(key_string.encode()).hexdigest()}"
@@ -70,17 +58,6 @@ class MemoryManager:
         """
         Retrieves file content by its path, implementing a full L0->L1->L3 fallback
         with cache stampede protection and automatic cache back-filling.
-
-        Args:
-            file_path: The path to the file within the Git repository.
-            commit_hash: The specific commit hash to retrieve. If None, uses the latest commit.
-
-        Returns:
-            The content of the file as a string.
-
-        Raises:
-            NotFoundError: If the file cannot be found in any memory layer.
-            MemoryLayerError: If a critical layer (L3) fails unexpectedly.
         """
         cache_key = self._generate_cache_key("file", file_path, commit_hash)
 
@@ -97,19 +74,15 @@ class MemoryManager:
                 logging.debug(f"L1 cache HIT for key: {cache_key}")
                 self.l0.set(cache_key, cached_value)  # Back-fill L0
                 return cached_value
-        except Exception as e:
+        except MemoryLayerError as e:
             logging.warning(f"L1 Redis GET failed for key '{cache_key}': {e}. Proceeding to L3.")
 
         # --- Cache Stampede Protection ---
-        # Acquire a lock specific to this key. If another request is already fetching
-        # this key, we will wait here until it's done.
         async with self._locks_lock:
             lock = self._locks.setdefault(cache_key, asyncio.Lock())
 
         async with lock:
             # --- Double-Check Locking Pattern ---
-            # Re-check L0/L1 now that we have the lock. The coroutine that acquired the
-            # lock before us might have already populated the cache.
             cached_value = self.l0.get(cache_key)
             if cached_value is not None:
                 logging.debug(f"L0 cache HIT (post-lock) for key: {cache_key}")
@@ -120,7 +93,7 @@ class MemoryManager:
                     logging.debug(f"L1 cache HIT (post-lock) for key: {cache_key}")
                     self.l0.set(cache_key, cached_value)
                     return cached_value
-            except Exception as e:
+            except MemoryLayerError as e:
                  logging.warning(f"L1 Redis GET (post-lock) failed for key '{cache_key}': {e}.")
 
             # --- L3 Fallback Logic (Definitive Cache Miss) ---
@@ -131,15 +104,13 @@ class MemoryManager:
 
             if value is not None:
                 logging.info(f"Found key '{file_path}' in L3. Back-filling L1 and L0 caches.")
-                # Asynchronously back-fill the caches for future requests
                 try:
                     await self.l1.set(cache_key, value)
                     self.l0.set(cache_key, value)
-                except Exception as e:
+                except MemoryLayerError as e:
                     logging.warning(f"Failed to back-fill cache for key '{cache_key}': {e}")
 
             # --- Cleanup and Return ---
-            # Clean up the lock for this key once we're done to prevent memory leaks.
             async with self._locks_lock:
                 self._locks.pop(cache_key, None)
 
@@ -151,37 +122,23 @@ class MemoryManager:
     async def semantic_search(self, query: str, n_results: int = 5) -> Dict[str, Any]:
         """Performs a semantic search using the L2 ChromaDB layer."""
         logging.info(f"Performing semantic search in L2 (Chroma) for query: '{query[:50]}...'")
-        try:
-            return self.l2c.query(query, n_results)
-        except Exception as e:
-            # Wrap the original exception for better debugging
-            raise MemoryLayerError("L2-Chroma", f"Semantic search failed: {e}")
+        return self.l2c.query(query, n_results)
 
     async def persist_node(self, class_name: str, data: Dict[str, Any]) -> str:
         """Persists a new data object (node) to the L2 Weaviate layer."""
         logging.info(f"Persisting node to L2 (Weaviate) in class '{class_name}'.")
-        try:
-            uuid = self.l2w.add_node(class_name, data)
-            logging.info(f"Successfully persisted object to L2 with UUID: {uuid}")
-            return uuid
-        except Exception as e:
-            raise MemoryLayerError("L2-Weaviate", f"Persistence failed: {e}")
+        uuid = self.l2w.add_node(class_name, data)
+        logging.info(f"Successfully persisted object to L2 with UUID: {uuid}")
+        return uuid
 
     async def set_cache_item(self, key: str, value: Any, expire_seconds: int = 3600):
         """
-        Explicitly sets a value in the cache layers (L0, L1), useful for storing
-        computed results from AI analysis.
-
-        Args:
-            key: The unique key for the item.
-            value: The value to store (should be JSON-serializable if complex).
-            expire_seconds: The time-to-live for the item in the L1 cache.
+        Explicitly sets a value in the cache layers (L0, L1).
         """
         logging.info(f"Setting cache for key '{key}' with TTL {expire_seconds}s.")
         self.l0.set(key, value)
         try:
-            # In a real system, complex objects should be serialized to JSON strings
-            value_to_store = json.dumps(value) if isinstance(value, (dict, list)) else value
+            value_to_store = json.dumps(value) if isinstance(value, (dict, list)) else str(value)
             await self.l1.set(key, value_to_store, expire=expire_seconds)
-        except Exception as e:
+        except MemoryLayerError as e:
             logging.warning(f"L1 Redis SET failed for key '{key}': {e}.")

--- a/tests/test_advanced_api.py
+++ b/tests/test_advanced_api.py
@@ -4,7 +4,7 @@ from httpx import AsyncClient
 
 @pytest.mark.asyncio
 async def test_temporal_logging(async_test_app_client: AsyncClient):
-    resp = await async_test_app_client.post("/advanced/temporal/user1", params={"action": "edit"})
+    resp = await async_test_app_client.post("/api/v1/advanced/temporal/user1", params={"action": "edit"})
     assert resp.status_code == 200
     data = resp.json()
     assert "sequence" in data
@@ -12,13 +12,13 @@ async def test_temporal_logging(async_test_app_client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_topology_cluster(async_test_app_client: AsyncClient):
-    resp = await async_test_app_client.get("/advanced/topology/cluster")
+    resp = await async_test_app_client.get("/api/v1/advanced/topology/cluster")
     assert resp.status_code == 200
     assert "labels" in resp.json()
 
 
 @pytest.mark.asyncio
 async def test_agent_run(async_test_app_client: AsyncClient):
-    resp = await async_test_app_client.post("/advanced/agents/run")
+    resp = await async_test_app_client.post("/api/v1/advanced/agents/run")
     assert resp.status_code == 200
     assert "best_position" in resp.json()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -55,7 +55,7 @@ async def test_get_file_success(
     file_content = "print('hello world')"
     mock_memory_manager.get_file_content.return_value = file_content
 
-    response = await async_test_app_client.get(f"/memory/file/{file_path}")
+    response = await async_test_app_client.get(f"/api/v1/memory/file/{file_path}")
 
     assert response.status_code == 200
     assert response.text == file_content
@@ -74,7 +74,7 @@ async def test_get_file_not_found(
         f"File '{file_path}' not found."
     )
 
-    response = await async_test_app_client.get(f"/memory/file/{file_path}")
+    response = await async_test_app_client.get(f"/api/v1/memory/file/{file_path}")
 
     assert response.status_code == 404
     assert response.json() == {"message": f"File '{file_path}' not found."}
@@ -91,7 +91,7 @@ async def test_get_file_memory_layer_failure(
         "L3-Git", "Repository is corrupted."
     )
 
-    response = await async_test_app_client.get(f"/memory/file/{file_path}")
+    response = await async_test_app_client.get(f"/api/v1/memory/file/{file_path}")
 
     assert response.status_code == 503
     assert "A required memory service is unavailable" in response.json()["message"]
@@ -112,7 +112,7 @@ async def test_semantic_search_success(
     mock_memory_manager.semantic_search.return_value = mock_response
 
     request_data = {"query": "test query", "top_k": 1}
-    response = await async_test_app_client.post("/memory/search", json=request_data)
+    response = await async_test_app_client.post("/api/v1/memory/search", json=request_data)
 
     assert response.status_code == 200
     assert response.json()["documents"][0][0] == "This is a test document."


### PR DESCRIPTION
## Summary
- update FastAPI startup and health check handling
- add API versioning prefix to routers
- adjust MemoryManager serialization and error handling
- clean up Redis client connection logic
- update tests to use new `/api/v1` prefix

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688213e27ca8832ea67d8f26f52afd04